### PR TITLE
Feature 74 Add ci: skip instruction

### DIFF
--- a/docs/source/build_config.rst
+++ b/docs/source/build_config.rst
@@ -35,6 +35,12 @@ in the root directory of your code:
 And it is done! Commit and push this config to you repository and ToxicBuild
 will execute this steps when a change is detected in your source code.
 
+.. note::
+
+   If you want same specific change in the repository doesn't trigger
+   any builds, you can use the instruction ``# ci: skip`` in the body of
+   the commit.
+
 These are the most basic configuration for a build, but the following
 parameters may be used in your builds:
 

--- a/docs/source/build_config.rst
+++ b/docs/source/build_config.rst
@@ -38,7 +38,7 @@ will execute this steps when a change is detected in your source code.
 .. note::
 
    If you want same specific change in the repository doesn't trigger
-   any builds, you can use the instruction ``# ci: skip`` in the body of
+   any builds, you can use the instruction ``ci: skip`` in the body of
    the commit.
 
 These are the most basic configuration for a build, but the following

--- a/tests/unit/core/test_vcs.py
+++ b/tests/unit/core/test_vcs.py
@@ -387,8 +387,8 @@ class GitTest(TestCase):
         def e(*a, **kw):
             assert a[0] == expected_cmd, a[0]
             log = '0sdflf093 | Thu Oct 20 16:30:23 2014 '
-            log += '| zezinha do butiá | some good commit | <end-toxiccommit>\n'
-            log += '0sdflf095 | Thu Oct 20 16:20:23 2014 '
+            log += '| zezinha do butiá | some good commit | <end-toxiccommit>'
+            log += '\n0sdflf095 | Thu Oct 20 16:20:23 2014 '
             log += '| seu fadu | Other good commit. | '
             log += body + '<end-toxiccommit>\n'
             log += '09s80f9asdf | Thu Oct 20 16:10:23 2014 '

--- a/tests/unit/core/test_vcs.py
+++ b/tests/unit/core/test_vcs.py
@@ -370,20 +370,30 @@ class GitTest(TestCase):
     def test_get_revisions_for_branch(self):
         now = utils.now()
         local = utils.utc2localtime(now)
-        expected_cmd = '{} log --pretty=format:"%H | %ad | %an | %s" '.format(
-            'git')
+
+        commit_fmt = "%H | %ad | %an | %s | %+b {}".format(
+            self.vcs._commit_separator)
+
+        expected_cmd = '{} log --pretty=format:"{}" '.\
+                       format('git', commit_fmt)
+
         expected_cmd += '--since="{}" --date=local'.format(
             datetime.datetime.strftime(local, self.vcs.date_format))
+
+        body = '\n\nObrigado deus dos maronitas.\nFadul Abdala\n'
+        body += 'O Grão-turco das putas.'
 
         @asyncio.coroutine
         def e(*a, **kw):
             assert a[0] == expected_cmd, a[0]
             log = '0sdflf093 | Thu Oct 20 16:30:23 2014 '
-            log += '| zezinha do butiá | some good commit\n'
+            log += '| zezinha do butiá | some good commit | <end-toxiccommit>\n'
             log += '0sdflf095 | Thu Oct 20 16:20:23 2014 '
-            log += '| seu fadu | Other good commit.\n'
+            log += '| seu fadu | Other good commit. | '
+            log += body + '<end-toxiccommit>\n'
             log += '09s80f9asdf | Thu Oct 20 16:10:23 2014 '
-            log += '| capitão natário | I was the last consumed\n'
+            log += '| capitão natário | I was the last consumed\n | '
+            log += '<end-toxiccommit>\n'
             return log
 
         vcs.exec_cmd = e
@@ -391,22 +401,31 @@ class GitTest(TestCase):
                                                                  since=now)
         # The first revision is the older one
         self.assertEqual(revisions[0]['author'], 'seu fadu')
+        self.assertEqual(revisions[0]['body'], body)
         self.assertEqual(revisions[1]['commit'], '0sdflf093')
 
     @async_test
     def test_get_revisions_for_branch_without_since(self):
-        expected_cmd = '{} log --pretty=format:"%H | %ad | %an | %s" {}'.\
-                       format('git', '--date=local')
+        commit_fmt = "%H | %ad | %an | %s | %+b {}".format(
+            self.vcs._commit_separator)
+
+        expected_cmd = '{} log --pretty=format:"{}" {}'.\
+                       format('git', commit_fmt, '--date=local')
+
+        body = '\n\nObrigado deus dos maronitas.\nFadul Abdala\n'
+        body += 'O Grão-turco das putas.'
 
         @asyncio.coroutine
         def e(*a, **kw):
             assert a[0] == expected_cmd, a[0]
             log = '0sdflf093 | Thu Oct 20 16:30:23 2014 '
-            log += '| zezinha do butiá | some good commit\n'
-            log += '0sdflf095 | Thu Oct 20 16:20:23 2014 '
-            log += '| seu fadu | Other good commit.\n'
+            log += '| zezinha do butiá | some good commit | <end-toxiccommit>'
+            log += '\n0sdflf095 | Thu Oct 20 16:20:23 2014 '
+            log += '| seu fadu | Other good commit. | '
+            log += body + '<end-toxiccommit>\n'
             log += '09s80f9asdf | Thu Oct 20 16:10:23 2014 '
-            log += '| capitão natário | I was the last consumed\n'
+            log += '| capitão natário | I was the last consumed\n | '
+            log += '<end-toxiccommit>\n'
             return log
 
         vcs.exec_cmd = e

--- a/tests/unit/master/test_repository.py
+++ b/tests/unit/master/test_repository.py
@@ -1047,6 +1047,21 @@ class RepositoryBranchTest(TestCase):
 class RepositoryRevisionTest(TestCase):
 
     @async_test
+    async def setUp(self):
+        self.user = users.User(email='a@a.com', password='bla')
+        await self.user.save()
+        self.repo = repository.Repository(name='bla', url='bla@bl.com/aaa',
+                                          owner=self.user)
+        await self.repo.save()
+        self.rev = repository.RepositoryRevision(repository=self.repo,
+                                                 commit='asdfasf',
+                                                 branch='master',
+                                                 author='ze',
+                                                 title='bla',
+                                                 commit_date=utils.now())
+        await self.rev.save()
+
+    @async_test
     async def tearDown(self):
         await repository.RepositoryRevision.drop_collection()
         await repository.Repository.drop_collection()
@@ -1054,74 +1069,47 @@ class RepositoryRevisionTest(TestCase):
 
     @async_test
     async def test_get(self):
-        user = users.User(email='a@a.com', password='bla')
-        await user.save()
-        repo = repository.Repository(name='bla', url='bla@bl.com/aaa',
-                                     owner=user)
-        await repo.save()
-        rev = repository.RepositoryRevision(repository=repo,
-                                            commit='asdfasf',
-                                            branch='master',
-                                            author='ze',
-                                            title='bla',
-                                            commit_date=utils.now())
-        await rev.save()
         r = await repository.RepositoryRevision.get(
-            commit='asdfasf', repository=repo)
-        self.assertEqual(r, rev)
+            commit='asdfasf', repository=self.repo)
+        self.assertEqual(r, self.rev)
 
     @async_test
     async def test_to_dict(self):
-        user = users.User(email='a@a.com', password='bla')
-        await user.save()
-        repo = repository.Repository(name='bla', url='bla@bl.com/aaa',
-                                     owner=user)
-        await repo.save()
-        rev = repository.RepositoryRevision(repository=repo,
-                                            commit='asdfasf',
-                                            branch='master',
-                                            author='ze',
-                                            title='bla',
-                                            commit_date=utils.now())
-        await rev.save()
-        expected = {'repository_id': str(repo.id),
-                    'commit': rev.commit,
-                    'branch': rev.branch,
-                    'author': rev.author,
-                    'title': rev.title,
+        expected = {'repository_id': str(self.repo.id),
+                    'commit': self.rev.commit,
+                    'branch': self.rev.branch,
+                    'author': self.rev.author,
+                    'title': self.rev.title,
                     'commit_date': repository.utils.datetime2string(
-                        rev.commit_date)}
-        returned = await rev.to_dict()
+                        self.rev.commit_date)}
+        returned = await self.rev.to_dict()
         self.assertEqual(expected, returned)
 
     @async_test
     async def test_to_dict_external(self):
-        user = users.User(email='a@a.com', password='bla')
-        await user.save()
-        repo = repository.Repository(name='bla', url='bla@bl.com/aaa',
-                                     owner=user)
-        await repo.save()
         ext = repository.ExternalRevisionIinfo(
             url='http://someurl.com/bla.git', name='other-remote',
             branch='master', into='other-remote:master')
-        rev = repository.RepositoryRevision(repository=repo,
-                                            commit='asdfasf',
-                                            branch='master',
-                                            author='ze',
-                                            title='bla',
-                                            commit_date=utils.now(),
-                                            external=ext)
-        await rev.save()
-        expected = {'repository_id': str(repo.id),
-                    'commit': rev.commit,
-                    'branch': rev.branch,
-                    'author': rev.author,
-                    'title': rev.title,
+        self.rev.external = ext
+        await self.rev.save()
+        expected = {'repository_id': str(self.repo.id),
+                    'commit': self.rev.commit,
+                    'branch': self.rev.branch,
+                    'author': self.rev.author,
+                    'title': self.rev.title,
                     'commit_date': repository.utils.datetime2string(
-                        rev.commit_date),
+                        self.rev.commit_date),
                     'external': {'branch': 'master',
                                  'name': 'other-remote',
                                  'url': 'http://someurl.com/bla.git',
                                  'into': 'other-remote:master'}}
-        returned = await rev.to_dict()
+        returned = await self.rev.to_dict()
         self.assertEqual(expected, returned)
+
+    def test_check_skip(self):
+        self.rev.body = 'some body\n# ci: skip'
+        self.assertFalse(self.rev.create_builds())
+
+    def test_check_skip_dont_skip(self):
+        self.rev.body = 'some body\n'
+        self.assertTrue(self.rev.create_builds())

--- a/tests/unit/master/test_repository.py
+++ b/tests/unit/master/test_repository.py
@@ -1107,7 +1107,7 @@ class RepositoryRevisionTest(TestCase):
         self.assertEqual(expected, returned)
 
     def test_check_skip(self):
-        self.rev.body = 'some body\n# ci: skip'
+        self.rev.body = 'some body\nhey you ci: skip please'
         self.assertFalse(self.rev.create_builds())
 
     def test_check_skip_dont_skip(self):

--- a/toxicbuild/master/build.py
+++ b/toxicbuild/master/build.py
@@ -564,6 +564,9 @@ class BuildManager(LoggerMixin):
 
         last_bs = None
         for revision in revisions:
+            if not revision.create_builds():
+                continue
+
             buildset = await BuildSet.create(repository=self.repository,
                                              revision=revision)
 

--- a/toxicbuild/master/repository.py
+++ b/toxicbuild/master/repository.py
@@ -922,7 +922,7 @@ class RepositoryRevision(Document):
         Known instructions:
         ```````````````````
 
-        - ``# ci: skip`` - If in the commit body there's this instruction,
+        - ``ci: skip`` - If in the commit body there's this instruction,
            no builds will be created for this revision. The regex for
            match this instruction is ``#\s*ci:\s*skip(\s+|$)``
         """
@@ -933,7 +933,7 @@ class RepositoryRevision(Document):
         return not self._check_skip()
 
     def _check_skip(self):
-        skip_pattern = re.compile(r'#\s*ci:\s*skip(\s+|$)')
+        skip_pattern = re.compile(r'(^|.*\s+)ci:\s*skip(\s+|$)')
         for l in self.body.split('\n'):
             if bool(re.match(skip_pattern, l)):
                 return True

--- a/toxicbuild/master/repository.py
+++ b/toxicbuild/master/repository.py
@@ -687,19 +687,22 @@ class Repository(OwnedDocument, utils.LoggerMixin):
         return branches
 
     async def add_revision(self, branch, commit, commit_date, author, title,
-                           external=None):
+                           body=None, external=None):
         """ Adds a revision to the repository.
 
         :param commit: commit uuid
         :param branch: branch name
         :param commit_date: commit's date (on authors time)
+        :param author: The author of the commit
+        :param title: The commit title.
+        :param body: The commit body.
         :param external: Information about an external remote if the revision
           came from an external.
         """
 
         kw = dict(repository=self, commit=commit,
                   branch=branch, commit_date=commit_date,
-                  author=author, title=title)
+                  author=author, title=title, body=body)
         if external:
             external_rev = ExternalRevisionIinfo(**external)
             kw['external'] = external_rev
@@ -882,6 +885,9 @@ class RepositoryRevision(Document):
     title = StringField(required=True)
     """The title of the commit."""
 
+    body = StringField()
+    """The commit body."""
+
     commit_date = DateTimeField(required=True)
     """Commit's date."""
 
@@ -908,3 +914,28 @@ class RepositoryRevision(Document):
         if self.external:
             rev_dict.update({'external': self.external.to_dict()})
         return rev_dict
+
+    def create_builds(self):
+        """Checks for instructions in the commit body to know if a
+        revision should create builds.
+
+        Known instructions:
+        ```````````````````
+
+        - ``# ci: skip`` - If in the commit body there's this instruction,
+           no builds will be created for this revision. The regex for
+           match this instruction is ``#\s*ci:\s*skip(\s+|$)``
+        """
+        if not self.body:
+            # No body, no instructions, we create builds normally
+            return True
+
+        return not self._check_skip()
+
+    def _check_skip(self):
+        skip_pattern = re.compile(r'#\s*ci:\s*skip(\s+|$)')
+        for l in self.body.split('\n'):
+            if bool(re.match(skip_pattern, l)):
+                return True
+
+        return False


### PR DESCRIPTION
When in the body of the commit there's the instruction ci: skip no builds are created for this revision